### PR TITLE
Fix README wheel download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Two options exist for automatic setup on macOS: with and without Anaconda
 - Activate the virtual environment by running `source ternaries-env/bin/activate`
 - Update `pip` by running `pip install --upgrade pip`
 - Build the `quick-ternaries` package from source by running `pip install git+https://github.com/ariessunfeld/quick-ternaries.git`
-  - NOTE: If you do not have Git installed, download the latest `.whl` file from the [`dist`](https://github.com/ariessunfeld/quick-ternaries/tree/main/dist) folder in this repository and run `pip install path/to/that/file.whl`
+  - NOTE: If you do not have Git installed, download the latest `.whl` file from the [latest Quick Ternaries release](https://github.com/ariessunfeld/quick-ternaries/releases/latest) under **Assets** and run `pip install path/to/that/file.whl`
 - Launch the tool (and test installation) by running `quick-ternaries`
 
 ## Windows
@@ -129,7 +129,7 @@ Two options exist for automatic setup on Windows: with and without Anaconda.
 - Activate the virtual environment by running `call ternaries-env\Scripts\activate.bat`
 - Update `pip` by running `pip install --upgrade pip`
 - Build the `quick-ternaries` package from source by running the command `pip install git+https://github.com/ariessunfeld/quick-ternaries.git`
-  - NOTE: If you do not have Git installed, download the latest `.whl` file from the [`dist`](https://github.com/ariessunfeld/quick-ternaries/tree/main/dist) folder in this repository and run `pip install path\to\that\file.whl`
+  - NOTE: If you do not have Git installed, download the latest `.whl` file from the [latest Quick Ternaries release](https://github.com/ariessunfeld/quick-ternaries/releases/latest) under **Assets** and run `pip install path\to\that\file.whl`
 - Launch the tool (and test installation) by running the command `quick-ternaries`
 
 # Using Quick Ternaries


### PR DESCRIPTION
### Motivation
- The manual installation instructions pointed users to the repository `dist` folder for `.whl` downloads which is missing and produced a dead URL, so the README should direct users to the releases Assets page instead.

### Description
- Replace the `dist`-folder wheel-download link with the GitHub `releases/latest` page URL under **Assets** in both the macOS and Windows Manual install sections of `README.md`.

### Testing
- Ran a small automated check via a `python` snippet that asserts the old `https://github.com/ariessunfeld/quick-ternaries/tree/main/dist` URL is no longer present and that `https://github.com/ariessunfeld/quick-ternaries/releases/latest` appears twice, and the assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1daf6c55e4832d94f1b8df43e1add9)