### PR TITLE
Clarify Windows Python 3.11 installation requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you found Quick Ternaries useful in your work, please feel free to cite it as
 
 Below are installation instructions for macOS and Windows. Regardless of your operating system, we recommend following the Automatic setup instructions, and launching the tool with the provided launcher. This way, each time you boot up the tool, it will check for updates and offer to install them if any are found.
 
-Note: This tool requires Python 3.11.
+Note: This tool requires Python 3.11. Newer Python versions, including Python 3.12 or 3.13, are not supported by the pinned scientific dependencies.
 
 For basic instructions on how to use the Terminal/Command Prompt, see the [New to the Terminal](#new-to-the-terminal) section.
 
@@ -125,11 +125,16 @@ Two options exist for automatic setup on Windows: with and without Anaconda.
 ### Manual
 
 - Open the Command Prompt and navigate to the location where you want to install the tool
-- Create a new virtual environment called `ternaries-env` (or whatever you like) by running the command `python3.11 -m venv ternaries-env`
+- Confirm that Command Prompt can find Python 3.11 by running `py -3.11 --version`. It should print a version like `Python 3.11.x`.
+  - If that command is not recognized, install Python 3.11 from [python.org](https://www.python.org/downloads/windows/) and make sure to check **Add python.exe to PATH** during installation.
+  - Do not use Python 3.12 or 3.13 for the virtual environment; Quick Ternaries currently requires Python 3.11.
+- Create a new virtual environment called `ternaries-env` (or whatever you like) by running the command `py -3.11 -m venv ternaries-env`
 - Activate the virtual environment by running `call ternaries-env\Scripts\activate.bat`
-- Update `pip` by running `pip install --upgrade pip`
-- Build the `quick-ternaries` package from source by running the command `pip install git+https://github.com/ariessunfeld/quick-ternaries.git`
-  - NOTE: If you do not have Git installed, download the latest `.whl` file from the [latest Quick Ternaries release](https://github.com/ariessunfeld/quick-ternaries/releases/latest) under **Assets** and run `pip install path\to\that\file.whl`
+- Verify that the active virtual environment is using Python 3.11 by running `python --version`
+- Update `pip` by running `python -m pip install --upgrade pip`
+- Build the `quick-ternaries` package from source by running the command `python -m pip install git+https://github.com/ariessunfeld/quick-ternaries.git`
+  - NOTE: If you do not have Git installed, download the latest `.whl` file from the [latest Quick Ternaries release](https://github.com/ariessunfeld/quick-ternaries/releases/latest) under **Assets** and run `python -m pip install path\to\that\file.whl`
+  - If `pip` downloads `numpy-1.26.4.tar.gz` and reports `ERROR: Unknown compiler(s)` or `Could not find ... vswhere.exe`, the virtual environment is almost certainly not using Python 3.11. Delete the environment, install Python 3.11, and recreate it with `py -3.11 -m venv ternaries-env`.
 - Launch the tool (and test installation) by running the command `quick-ternaries`
 
 # Using Quick Ternaries

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
 
 [options]
 packages = find:
+python_requires = >=3.11,<3.12
 zip_safe = False
 include_package_data = True
 install_requires =


### PR DESCRIPTION
### Motivation
- The Windows manual install error shows `pip` downloading `numpy-1.26.4.tar.gz` and Meson failing to find native compilers (`cl`, `gcc`, `vswhere.exe`), which is symptomatic of pip trying to build NumPy from source instead of installing a wheel. 
- That symptom occurs when the virtual environment is using an unsupported Python interpreter (e.g. 3.12+), so we want to fail earlier and give clearer guidance to users. 
- The goal is to make the installer behavior and resolution obvious for Windows users who follow the manual (non‑Conda) instructions.

### Description
- Add `python_requires = >=3.11,<3.12` to `setup.cfg` so unsupported interpreters are rejected at package metadata resolution. 
- Update the Windows manual installation section in `README.md` to use the Python launcher (`py -3.11`), to recommend creating the venv with `py -3.11 -m venv`, to verify the active venv with `python --version`, and to use `python -m pip` for subsequent installs. 
- Explicitly document the `numpy-1.26.4.tar.gz` / `Unknown compiler(s)` / `vswhere.exe` error as a likely indicator that the venv is not using Python 3.11 and advise deleting and recreating the venv with `py -3.11 -m venv`.

### Testing
- Verified `setup.cfg` exposes `python_requires = >=3.11,<3.12` using a small `ConfigParser` check, which succeeded. 
- Ran `git diff --check` style validation which passed with no whitespace/patch errors. 
- `pytest -q` could not be executed in this environment because required test dependencies (notably `pandas`) were not installed, so full test suite was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1db2e81d30832d842a1a1ee68b00d6)