### PR TITLE
[codex] bump package version for v1.0.1 release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = quick-ternaries
-version = 0.10.3
+version = 1.0.1
 author = Ari Essunfeld, Reid Morris
 author_email = ariessunfeld@gmail.com, reidmorris0419@gmail.com
 description = A tool for making ternary diagrams and other scientific data visualizations


### PR DESCRIPTION
## Summary

Bumps the package metadata version from `0.10.3` to `1.0.1` so the next GitHub package release can align the release tag, wheel metadata, and launcher updater behavior.

## Why

The refreshed launcher assets install/update from GitHub's latest release. Latest is currently `v1.0.0`, which predates the Python 3.11-3.14 dependency compatibility changes. Publishing a new `v1.0.1` release from `main` should use matching package metadata so launchers install the updated code and do not keep comparing an installed `0.10.3` package against a `v1.x` release tag.

## Validation

- `python3 -c "import configparser; c=configparser.ConfigParser(); c.read('setup.cfg'); assert c['metadata']['version'] == '1.0.1'; print(c['metadata']['name'], c['metadata']['version'])"`
- `/private/tmp/quick-ternaries-ci-312/bin/python -m pip wheel . --no-deps -w /private/tmp/quick-ternaries-release-build-1.0.1` -> built `quick_ternaries-1.0.1-py3-none-any.whl`
- `git diff --check`