### PR TITLE
[codex] avoid duplicate launcher Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       - ci
   - package-ecosystem: pip
     directory: /
+    exclude-paths:
+      - launcher/**
     schedule:
       interval: weekly
     labels:


### PR DESCRIPTION
## Summary

Prevents the root `pip` Dependabot entry from also scanning launcher dependency files.

## Why

After Dependabot was enabled, it opened duplicate `requests` PRs because both the root `pip` entry and the `/launcher` `pip` entry detected `launcher/requirements.txt`. The `/launcher` entry should own launcher dependency updates.

## Change

- Adds `exclude-paths: [launcher/**]` to the root `pip` Dependabot config.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/dependabot.yml'); puts 'dependabot yaml ok'"`
- `git diff --check`