### PR TITLE
[codex] update citation guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: CI
 
 on:
+  workflow_dispatch:
+    inputs:
+      full_ci:
+        description: Run the full install matrix
+        required: false
+        type: boolean
+        default: true
   push:
     branches:
       - main
@@ -21,8 +28,94 @@ env:
   XDG_CACHE_HOME: .cache/xdg
 
 jobs:
+  ci_scope:
+    name: CI scope
+    runs-on: ubuntu-latest
+    outputs:
+      run_full_ci: ${{ steps.scope.outputs.run_full_ci }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine CI scope
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          WORKFLOW_DISPATCH_FULL_CI: ${{ inputs.full_ci }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base="$PR_BASE_SHA"
+            head="$PR_HEAD_SHA"
+          elif [[ -n "${BEFORE_SHA:-}" && "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]]; then
+            base="$BEFORE_SHA"
+            head="$GITHUB_SHA"
+          else
+            base=""
+            head="$GITHUB_SHA"
+          fi
+
+          run_full_ci=false
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            run_full_ci="${WORKFLOW_DISPATCH_FULL_CI:-true}"
+            changed_files="manual workflow dispatch"
+          else
+            if [[ -z "$base" ]] || ! git cat-file -e "$base^{commit}" || ! git cat-file -e "$head^{commit}"; then
+              run_full_ci=true
+              changed_files="unknown"
+            else
+              changed_files="$(git diff --name-only "$base" "$head")"
+              if [[ -z "$changed_files" ]]; then
+                run_full_ci=true
+              else
+                while IFS= read -r file; do
+                  case "$file" in
+                    README.md|CITATION.cff|*.md|docs/*|docs/**|img/*|img/**)
+                      ;;
+                    *)
+                      run_full_ci=true
+                      ;;
+                  esac
+                done <<< "$changed_files"
+              fi
+
+              git diff --check "$base" "$head"
+            fi
+          fi
+
+          if [[ -f CITATION.cff ]]; then
+            ruby -e "require 'yaml'; YAML.load_file('CITATION.cff')"
+          fi
+
+          {
+            echo "run_full_ci=$run_full_ci"
+            echo "changed_files<<EOF"
+            printf '%s\n' "$changed_files"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### CI scope"
+            echo
+            echo "Full install matrix: \`$run_full_ci\`"
+            echo
+            echo "Changed files:"
+            echo
+            printf '%s\n' "$changed_files" | sed 's/^/- /'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   manual-install:
     name: Manual install (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    needs: ci_scope
+    if: needs.ci_scope.outputs.run_full_ci == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -81,6 +174,8 @@ jobs:
 
   conda-install:
     name: Conda-assisted install (Python ${{ matrix.python-version }})
+    needs: ci_scope
+    if: needs.ci_scope.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -142,6 +237,8 @@ jobs:
 
   conda-environment-file:
     name: Conda launcher environment file
+    needs: ci_scope
+    if: needs.ci_scope.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,11 @@
+cff-version: 1.2.0
+message: "If Quick Ternaries is useful in your work, please cite the archived Zenodo record for the version you used."
+title: "Quick Ternaries"
+type: software
+authors:
+  - family-names: Essunfeld
+    given-names: Ari
+  - family-names: Morris
+    given-names: Reid
+doi: 10.5281/zenodo.14511221
+repository-code: "https://github.com/ariessunfeld/quick-ternaries"

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ Quick Ternaries is a python application designed to make ternary plotting a bree
 
 ## Citation
 
-If you found Quick Ternaries useful in your work, please feel free to cite it as follows:
+If Quick Ternaries is useful in your work, please cite the archived Zenodo record for the version you used. The DOI badge below resolves to the latest archived version, and Zenodo provides BibTeX and other export formats from that page.
+
+For a version-independent citation to the Quick Ternaries project, use the concept DOI:
 
 <pre>
-@misc{essunfeld2025quick,
+@software{essunfeld_quick_ternaries,
   author       = {Ari Essunfeld and Reid Morris},
-  title        = {Quick Ternaries: v0.5.3},
-  year         = {2025},
+  title        = {Quick Ternaries},
   publisher    = {Zenodo},
-  version      = {v0.5.3},
   doi          = {10.5281/zenodo.14511221},
   url          = {https://doi.org/10.5281/zenodo.14511221},
   howpublished = {Software available from Zenodo}


### PR DESCRIPTION
## Summary
- Replace the stale hard-coded v0.5.3 README BibTeX with version-neutral Zenodo concept DOI guidance.
- Add `CITATION.cff` so GitHub can expose structured citation metadata.
- Add a lightweight `CI scope` gate so docs-only changes skip the expensive install matrix, while code/dependency/launcher/workflow changes still run full CI.
- Add a manual `workflow_dispatch` `full_ci` switch for forcing the full matrix from the Actions tab.

## Rationale
Zenodo creates a new version DOI for each release after the release exists. Keeping a version-specific BibTeX block in README would require post-release churn every time. The concept DOI resolves to the latest archived version, while the README now tells users to use Zenodo's export for the exact version they used.

The full CI matrix is valuable for code and installation changes, but it is unnecessary for README/CITATION-only edits. The new scope gate keeps a visible cheap check on every run and only starts the full matrix when the changed files warrant it.

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('CITATION.cff'); puts 'CITATION.cff yaml ok'"`
- `ruby -e "require 'yaml'; y=YAML.load_file('.github/workflows/ci.yml'); abort 'missing ci_scope' unless y.fetch('jobs').key?('ci_scope'); puts 'workflow yaml ok'"`
- `bash -n /private/tmp/quick-ternaries-ci-scope.sh`
- `git diff --check HEAD~2..HEAD`
- Local gate simulation: docs-only diff returned `run_full_ci=false`.
- Local gate simulation: this PR's workflow/doc diff returned `run_full_ci=true`.
- Local gate simulation: manual dispatch `full_ci=true` returned `run_full_ci=true`; `full_ci=false` returned `run_full_ci=false`.