### PR TITLE
[codex] fix Zenodo DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For a version-independent citation to the Quick Ternaries project, use the conce
 }
 </pre>
 
-[![DOI](https://zenodo.org/badge/709465811.svg)](https://doi.org/10.5281/zenodo.14511221)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14511221.svg)](https://doi.org/10.5281/zenodo.14511221)
 
 # Table of Contents
 


### PR DESCRIPTION
## Summary
- Replace the redirecting Zenodo repository badge URL with the direct concept-DOI badge SVG URL.

## Rationale
The old `https://zenodo.org/badge/709465811.svg` endpoint redirects to the latest version-specific DOI badge. The README image failed to render through GitHub, so this uses the direct `https://zenodo.org/badge/DOI/10.5281/zenodo.14511221.svg` endpoint instead.

## Validation
- `curl -fsSL https://zenodo.org/badge/DOI/10.5281/zenodo.14511221.svg`
- `git diff --check`