### PR TITLE
[codex] Add legend position controls

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: git-diff-check
+        name: Check staged whitespace with git diff --check
+        entry: git diff --cached --check
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ For a version-independent citation to the Quick Ternaries project, use the conce
   - [Opening the Terminal / Command Prompt](#opening-the-terminal--command-prompt)
   - [Running Commands](#running-commands)
   - [Navigating to a Directory](#navigating-to-a-directory)
+- [Development Checks](#development-checks)
 - [Copyright and License](#copyright-and-license)
 - [Contact](#contact)
 
@@ -314,6 +315,17 @@ When you read "Run the following command...", that means to type the command int
 To move around different folders in the Terminal or Command Prompt, use the `cd` command. on macOS, the easiest way to get to a specific location is to open the Finder, locate the folder you want to be in, right-click the folder, then hold down the `option` key and choose `copy [foldername] as Pathname`. Then go back to the Terminal and type `cd`, then hit the `Space` bar, and then paste the pathname you copied by pressing `Cmd+V`. So, for example, if the path you copied was `/Users/yourname/Documents/someFolder/anotherFolder/`, the command would look like `cd /Users/yourname/Documents/someFolder/anotherFolder/`. 
 
 In the Command Prompt, the process is similar. The easiest way to get to a specific folder in the Command Prompt is to open the File Browser, navigate to the desired folder, then click in the textbox at the top of the window and copy the path shown there, likely starting with `C:\...`. Then go into the Command Prompt and run the command `cd C:\...`, pasting the path you copied where the `C:\...` is.
+
+# Development Checks
+
+For local development, install the development extra and enable the pre-commit hook:
+
+```bash
+python -m pip install ".[dev]"
+python -m pre_commit install
+```
+
+The hook runs `git diff --cached --check` before each commit. This matches the CI whitespace check and catches trailing whitespace in staged changes before the branch is pushed.
 
 # Copyright and License
 

--- a/quick_ternaries/models/advanced_setup_menu_model.py
+++ b/quick_ternaries/models/advanced_setup_menu_model.py
@@ -12,6 +12,13 @@ from quick_ternaries.views.widgets import (
     ColorScaleDropdown, 
     ColorButton
 )
+from quick_ternaries.utils.legend_layout import (
+    LEGEND_COORDINATE_REFERENCE_OPTIONS,
+    LEGEND_ORIENTATION_OPTIONS,
+    LEGEND_POSITION_OPTIONS,
+    LEGEND_X_ANCHOR_OPTIONS,
+    LEGEND_Y_ANCHOR_OPTIONS,
+)
 
 
 @dataclass
@@ -144,8 +151,74 @@ class AdvancedPlotSettingsModel:
         default="top-right",
         metadata={
             "label": "Legend Position:",
-            "widget": QLineEdit,
+            "widget": QComboBox,
             "plot_types": ["cartesian", "histogram", "ternary"],
+            "options": LEGEND_POSITION_OPTIONS,
+        },
+    )
+    legend_x: float = field(
+        default=1.0,
+        metadata={
+            "label": "Legend X Position:",
+            "widget": QDoubleSpinBox,
+            "plot_types": ["cartesian", "histogram", "ternary"],
+            "depends_on": ("legend_position", "custom"),
+            "minimum": -2.0,
+            "maximum": 3.0,
+            "single_step": 0.05,
+            "decimals": 3,
+        },
+    )
+    legend_y: float = field(
+        default=1.0,
+        metadata={
+            "label": "Legend Y Position:",
+            "widget": QDoubleSpinBox,
+            "plot_types": ["cartesian", "histogram", "ternary"],
+            "depends_on": ("legend_position", "custom"),
+            "minimum": -2.0,
+            "maximum": 3.0,
+            "single_step": 0.05,
+            "decimals": 3,
+        },
+    )
+    legend_coordinate_reference: str = field(
+        default="paper",
+        metadata={
+            "label": "Legend Coordinate Reference:",
+            "widget": QComboBox,
+            "plot_types": ["cartesian", "histogram", "ternary"],
+            "depends_on": ("legend_position", "custom"),
+            "options": LEGEND_COORDINATE_REFERENCE_OPTIONS,
+        },
+    )
+    legend_xanchor: str = field(
+        default="right",
+        metadata={
+            "label": "Legend X Anchor:",
+            "widget": QComboBox,
+            "plot_types": ["cartesian", "histogram", "ternary"],
+            "depends_on": ("legend_position", "custom"),
+            "options": LEGEND_X_ANCHOR_OPTIONS,
+        },
+    )
+    legend_yanchor: str = field(
+        default="top",
+        metadata={
+            "label": "Legend Y Anchor:",
+            "widget": QComboBox,
+            "plot_types": ["cartesian", "histogram", "ternary"],
+            "depends_on": ("legend_position", "custom"),
+            "options": LEGEND_Y_ANCHOR_OPTIONS,
+        },
+    )
+    legend_orientation: str = field(
+        default="vertical",
+        metadata={
+            "label": "Legend Orientation:",
+            "widget": QComboBox,
+            "plot_types": ["cartesian", "histogram", "ternary"],
+            "options": LEGEND_ORIENTATION_OPTIONS,
         },
     )
     font_size: int = field(

--- a/quick_ternaries/services/cartesian_plot_maker.py
+++ b/quick_ternaries/services/cartesian_plot_maker.py
@@ -6,6 +6,7 @@ import plotly.graph_objects as go
 from plotly.graph_objects import Figure, Layout
 
 from quick_ternaries.services.cartesian_trace_maker import CartesianTraceMaker
+from quick_ternaries.utils.legend_layout import build_legend_layout
 from quick_ternaries.utils.plotly_html import write_plotly_html
 
 from PySide6.QtWidgets import QMessageBox
@@ -141,14 +142,6 @@ class CartesianPlotMaker:
                 linewidth=1,
                 mirror=True
             ),
-            # legend=dict(
-            #     x=1,
-            #     y=1,
-            #     xanchor='right',
-            #     yanchor='top',
-            #     bordercolor='#888',
-            #     borderwidth=1
-            # )
         )
         
         # Apply advanced settings if available
@@ -265,30 +258,7 @@ class CartesianPlotMaker:
         if layout.title:
             layout.title.font = font_settings
         
-        # Legend position
-        # if hasattr(advanced_settings, 'legend_position'):
-        #     position = advanced_settings.legend_position.lower()
-        #     layout.legend.font = font_settings
-            
-        #     if 'top' in position:
-        #         layout.legend.y = 1
-        #         layout.legend.yanchor = 'top'
-        #     elif 'bottom' in position:
-        #         layout.legend.y = 0
-        #         layout.legend.yanchor = 'bottom'
-        #     else:
-        #         layout.legend.y = 0.5
-        #         layout.legend.yanchor = 'middle'
-                
-        #     if 'left' in position:
-        #         layout.legend.x = 0
-        #         layout.legend.xanchor = 'left'
-        #     elif 'right' in position:
-        #         layout.legend.x = 1
-        #         layout.legend.xanchor = 'right'
-        #     else:
-        #         layout.legend.x = 0.5
-        #         layout.legend.xanchor = 'center'
+        layout.legend = build_legend_layout(advanced_settings, font_settings)
                 
     def _add_axis_labels(self, layout: Layout, setup_model):
         """

--- a/quick_ternaries/services/ternary_plot_maker.py
+++ b/quick_ternaries/services/ternary_plot_maker.py
@@ -8,6 +8,7 @@ from plotly.graph_objects import Figure, Layout
 
 from quick_ternaries.services.ternary_trace_maker import TernaryTraceMaker
 from quick_ternaries.services.axis_formatter import AxisFormatter
+from quick_ternaries.utils.legend_layout import build_legend_layout
 
 class LayoutCreator:
     """
@@ -53,6 +54,12 @@ class LayoutCreator:
                 ternary_sum = int(advanced_settings.ternary_sum)
             except (ValueError, AttributeError):
                 pass
+
+        font_settings = dict(
+            family=advanced_settings.font if hasattr(advanced_settings, 'font') else 'Arial',
+            size=advanced_settings.font_size if hasattr(advanced_settings, 'font_size') else 12,
+            color=advanced_settings.font_color if hasattr(advanced_settings, 'font_color') else '#000000'
+        )
         
         return dict(
             ternary=dict(
@@ -64,11 +71,9 @@ class LayoutCreator:
                 sum=ternary_sum,
             ),
             title=dict(
-                font=dict(
-                    family=advanced_settings.font if hasattr(advanced_settings, 'font') else 'Arial',
-                    size=advanced_settings.font_size if hasattr(advanced_settings, 'font_size') else 12
-                )
+                font=font_settings
             ),
+            legend=build_legend_layout(advanced_settings, font_settings),
             paper_bgcolor=TernaryTraceMaker()._convert_hex_to_rgba(advanced_settings.paper_color) if hasattr(advanced_settings, 'paper_color') else "#FFFFFF"
 
         )

--- a/quick_ternaries/utils/legend_layout.py
+++ b/quick_ternaries/utils/legend_layout.py
@@ -1,0 +1,136 @@
+"""Helpers for applying shared Plotly legend layout settings."""
+
+from typing import Any, Dict
+
+
+LEGEND_POSITION_PRESETS = {
+    "top-left": {"x": 0.0, "y": 1.0, "xanchor": "left", "yanchor": "top"},
+    "top-center": {"x": 0.5, "y": 1.0, "xanchor": "center", "yanchor": "top"},
+    "top-right": {"x": 1.0, "y": 1.0, "xanchor": "right", "yanchor": "top"},
+    "center-left": {"x": 0.0, "y": 0.5, "xanchor": "left", "yanchor": "middle"},
+    "center": {"x": 0.5, "y": 0.5, "xanchor": "center", "yanchor": "middle"},
+    "center-right": {"x": 1.0, "y": 0.5, "xanchor": "right", "yanchor": "middle"},
+    "bottom-left": {"x": 0.0, "y": 0.0, "xanchor": "left", "yanchor": "bottom"},
+    "bottom-center": {"x": 0.5, "y": 0.0, "xanchor": "center", "yanchor": "bottom"},
+    "bottom-right": {"x": 1.0, "y": 0.0, "xanchor": "right", "yanchor": "bottom"},
+}
+
+LEGEND_POSITION_OPTIONS = [
+    "top-right",
+    "top-left",
+    "bottom-right",
+    "bottom-left",
+    "top-center",
+    "bottom-center",
+    "center-right",
+    "center-left",
+    "center",
+    "custom",
+]
+
+LEGEND_X_ANCHOR_OPTIONS = ["left", "center", "right"]
+LEGEND_Y_ANCHOR_OPTIONS = ["top", "middle", "bottom"]
+LEGEND_ORIENTATION_OPTIONS = ["vertical", "horizontal"]
+LEGEND_COORDINATE_REFERENCE_OPTIONS = ["paper", "container"]
+
+_POSITION_ALIASES = {
+    "left-top": "top-left",
+    "center-top": "top-center",
+    "right-top": "top-right",
+    "left-center": "center-left",
+    "middle-left": "center-left",
+    "left-middle": "center-left",
+    "middle": "center",
+    "right-center": "center-right",
+    "middle-right": "center-right",
+    "right-middle": "center-right",
+    "left-bottom": "bottom-left",
+    "center-bottom": "bottom-center",
+    "right-bottom": "bottom-right",
+}
+
+
+def normalize_legend_position(position: Any) -> str:
+    """Normalize saved/free-form legend position values to known options."""
+    normalized = str(position or "top-right").strip().lower()
+    normalized = normalized.replace("_", "-").replace(" ", "-")
+    return _POSITION_ALIASES.get(normalized, normalized)
+
+
+def _coerce_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_option(value: Any, allowed: list[str], default: str) -> str:
+    normalized = str(value or default).strip().lower()
+    return normalized if normalized in allowed else default
+
+
+def _orientation_value(value: Any) -> str:
+    normalized = str(value or "vertical").strip().lower()
+    return "h" if normalized.startswith("h") else "v"
+
+
+def _clamp_container_coordinate(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def build_legend_layout(
+    advanced_settings: Any,
+    font_settings: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    """Build a Plotly layout.legend dict from global advanced settings."""
+    position = normalize_legend_position(
+        getattr(advanced_settings, "legend_position", "top-right")
+    )
+    preset = LEGEND_POSITION_PRESETS.get(position, LEGEND_POSITION_PRESETS["top-right"])
+    coordinate_reference = "paper"
+
+    if position == "custom":
+        x = _coerce_float(getattr(advanced_settings, "legend_x", preset["x"]), preset["x"])
+        y = _coerce_float(getattr(advanced_settings, "legend_y", preset["y"]), preset["y"])
+        coordinate_reference = _coerce_option(
+            getattr(advanced_settings, "legend_coordinate_reference", "paper"),
+            LEGEND_COORDINATE_REFERENCE_OPTIONS,
+            "paper",
+        )
+        if coordinate_reference == "container":
+            x = _clamp_container_coordinate(x)
+            y = _clamp_container_coordinate(y)
+        xanchor = _coerce_option(
+            getattr(advanced_settings, "legend_xanchor", preset["xanchor"]),
+            LEGEND_X_ANCHOR_OPTIONS,
+            preset["xanchor"],
+        )
+        yanchor = _coerce_option(
+            getattr(advanced_settings, "legend_yanchor", preset["yanchor"]),
+            LEGEND_Y_ANCHOR_OPTIONS,
+            preset["yanchor"],
+        )
+    else:
+        x = preset["x"]
+        y = preset["y"]
+        xanchor = preset["xanchor"]
+        yanchor = preset["yanchor"]
+
+    legend = {
+        "x": x,
+        "y": y,
+        "xref": coordinate_reference,
+        "yref": coordinate_reference,
+        "xanchor": xanchor,
+        "yanchor": yanchor,
+        "orientation": _orientation_value(
+            getattr(advanced_settings, "legend_orientation", "vertical")
+        ),
+        "bordercolor": "#888",
+        "borderwidth": 1,
+    }
+
+    if font_settings:
+        legend["font"] = font_settings
+
+    return legend

--- a/quick_ternaries/views/setup_menu_view.py
+++ b/quick_ternaries/views/setup_menu_view.py
@@ -204,6 +204,15 @@ class SetupMenuView(QWidget):
                     )
                 )
             elif isinstance(field_widget, QDoubleSpinBox):
+                if "minimum" in metadata or "maximum" in metadata:
+                    field_widget.setRange(
+                        float(metadata.get("minimum", field_widget.minimum())),
+                        float(metadata.get("maximum", field_widget.maximum())),
+                    )
+                if "single_step" in metadata:
+                    field_widget.setSingleStep(float(metadata["single_step"]))
+                if "decimals" in metadata:
+                    field_widget.setDecimals(int(metadata["decimals"]))
                 field_widget.setValue(float(value))
                 field_widget.valueChanged.connect(
                     lambda val, fname=f.name, m=section_model: setattr(m, fname, val)
@@ -229,12 +238,18 @@ class SetupMenuView(QWidget):
                     lambda _: self._update_field_visibility()
                 )
             elif isinstance(field_widget, QComboBox):
-                field_widget.addItems([])
+                options = list(metadata.get("options", []))
                 if f.name == 'aspect_ratio':
-                    field_widget.addItems(["Automatic", "5x3", "2x1", "1x3", "1x1"])
+                    options = ["Automatic", "5x3", "2x1", "1x3", "1x1"]
+                field_widget.addItems(options)
+                if value and field_widget.findText(str(value)) == -1:
+                    field_widget.addItem(str(value))
                 field_widget.setCurrentText(str(value))
                 field_widget.currentTextChanged.connect(
                     lambda text, fname=f.name, m=section_model: setattr(m, fname, text)
+                )
+                field_widget.currentTextChanged.connect(
+                    lambda _: self._update_field_visibility()
                 )
             elif isinstance(field_widget, MultiFieldSelector):
                 field_widget.set_selected_fields(value)
@@ -365,23 +380,14 @@ class SetupMenuView(QWidget):
                 
                 # Check dependency condition
                 dep = metadata["depends_on"]
-                dep_met = False
-                
                 if isinstance(dep, list):
                     # Multiple dependencies - all must be met
-                    dep_met = True
-                    for d in dep:
-                        if isinstance(d, str):
-                            # Simple dependency on a boolean field
-                            dep_met = dep_met and bool(getattr(section_model, d, False))
-                        elif isinstance(d, tuple) and len(d) == 2:
-                            # Dependency on field having specific value
-                            dep_met = dep_met and getattr(section_model, d[0], None) == d[1]
-                        else:
-                            dep_met = False
+                    dep_met = all(
+                        self._dependency_condition_met(section_model, d)
+                        for d in dep
+                    )
                 else:
-                    # Single dependency
-                    dep_met = bool(getattr(section_model, dep, False))
+                    dep_met = self._dependency_condition_met(section_model, dep)
                 
                 # Final visibility is base_visible AND dep_met
                 visible = base_visible and dep_met
@@ -401,6 +407,21 @@ class SetupMenuView(QWidget):
                         label = form_layout.labelForField(field_widget)
                         if label:
                             label.hide()
+
+    @staticmethod
+    def _dependency_condition_met(section_model, dependency):
+        """Return whether a form field dependency is currently satisfied."""
+        if isinstance(dependency, str):
+            return bool(getattr(section_model, dependency, False))
+
+        if isinstance(dependency, tuple) and len(dependency) == 2:
+            field_name, expected_value = dependency
+            actual_value = getattr(section_model, field_name, None)
+            if isinstance(actual_value, str) and isinstance(expected_value, str):
+                return actual_value.strip().lower() == expected_value.strip().lower()
+            return actual_value == expected_value
+
+        return False
 
     def on_scale_changed(self, axis_name, column_name, scale_factor):
         """Handle when a scale factor is changed in the scaling widget."""
@@ -693,3 +714,5 @@ class SetupMenuView(QWidget):
         
         # Update the chemical formula widget
         self.update_formula_widget()
+        
+        self._update_field_visibility()

--- a/quick_ternaries/views/setup_menu_view.py
+++ b/quick_ternaries/views/setup_menu_view.py
@@ -711,8 +711,8 @@ class SetupMenuView(QWidget):
 
         # Update the column scaling widget
         self.update_scaling_widget()
-        
+
         # Update the chemical formula widget
         self.update_formula_widget()
-        
+
         self._update_field_visibility()

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,10 @@ install_requires =
 test =
     pytest>=8
     pytest-cov>=5
+dev =
+    pytest>=8
+    pytest-cov>=5
+    pre-commit>=4
 
 [options.entry_points]
 console_scripts =

--- a/tests/test_services/test_plot_legend_layout.py
+++ b/tests/test_services/test_plot_legend_layout.py
@@ -1,0 +1,37 @@
+from quick_ternaries.models.setup_menu_model import SetupMenuModel
+from quick_ternaries.services.cartesian_plot_maker import CartesianPlotMaker
+from quick_ternaries.services.ternary_plot_maker import TernaryPlotMaker
+
+
+def test_cartesian_layout_applies_custom_legend_settings():
+    setup_model = SetupMenuModel()
+    settings = setup_model.advanced_settings
+    settings.legend_position = "custom"
+    settings.legend_x = 1.2
+    settings.legend_y = 0.4
+    settings.legend_coordinate_reference = "paper"
+    settings.legend_xanchor = "left"
+    settings.legend_yanchor = "middle"
+    settings.legend_orientation = "horizontal"
+
+    layout = CartesianPlotMaker()._create_layout(setup_model)
+
+    assert layout.legend.x == 1.2
+    assert layout.legend.y == 0.4
+    assert layout.legend.xref == "paper"
+    assert layout.legend.yref == "paper"
+    assert layout.legend.xanchor == "left"
+    assert layout.legend.yanchor == "middle"
+    assert layout.legend.orientation == "h"
+
+
+def test_ternary_layout_applies_legend_position_preset():
+    setup_model = SetupMenuModel()
+    setup_model.advanced_settings.legend_position = "bottom-center"
+
+    layout = TernaryPlotMaker()._create_layout(setup_model)
+
+    assert layout.legend.x == 0.5
+    assert layout.legend.y == 0.0
+    assert layout.legend.xanchor == "center"
+    assert layout.legend.yanchor == "bottom"

--- a/tests/test_utils/test_legend_layout.py
+++ b/tests/test_utils/test_legend_layout.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+
+from quick_ternaries.utils.legend_layout import (
+    build_legend_layout,
+    normalize_legend_position,
+)
+
+
+def test_normalize_legend_position_accepts_legacy_freeform_values():
+    assert normalize_legend_position("Top Right") == "top-right"
+    assert normalize_legend_position("left bottom") == "bottom-left"
+    assert normalize_legend_position("middle") == "center"
+
+
+def test_build_legend_layout_uses_position_preset():
+    settings = SimpleNamespace(
+        legend_position="bottom-left",
+        legend_orientation="horizontal",
+    )
+    legend = build_legend_layout(settings, {"family": "Arial", "size": 12})
+
+    assert legend["x"] == 0.0
+    assert legend["y"] == 0.0
+    assert legend["xref"] == "paper"
+    assert legend["yref"] == "paper"
+    assert legend["xanchor"] == "left"
+    assert legend["yanchor"] == "bottom"
+    assert legend["orientation"] == "h"
+    assert legend["font"] == {"family": "Arial", "size": 12}
+
+
+def test_build_legend_layout_uses_custom_coordinates_and_anchors():
+    settings = SimpleNamespace(
+        legend_position="custom",
+        legend_x=1.25,
+        legend_y=-0.15,
+        legend_coordinate_reference="paper",
+        legend_xanchor="left",
+        legend_yanchor="bottom",
+        legend_orientation="vertical",
+    )
+    legend = build_legend_layout(settings)
+
+    assert legend["x"] == 1.25
+    assert legend["y"] == -0.15
+    assert legend["xref"] == "paper"
+    assert legend["yref"] == "paper"
+    assert legend["xanchor"] == "left"
+    assert legend["yanchor"] == "bottom"
+    assert legend["orientation"] == "v"
+
+
+def test_build_legend_layout_clamps_container_coordinates():
+    settings = SimpleNamespace(
+        legend_position="custom",
+        legend_x=1.25,
+        legend_y=-0.15,
+        legend_coordinate_reference="container",
+        legend_xanchor="left",
+        legend_yanchor="bottom",
+        legend_orientation="vertical",
+    )
+    legend = build_legend_layout(settings)
+
+    assert legend["x"] == 1.0
+    assert legend["y"] == 0.0
+    assert legend["xref"] == "container"
+    assert legend["yref"] == "container"

--- a/tests/test_views/test_setup_menu_view.py
+++ b/tests/test_views/test_setup_menu_view.py
@@ -1,0 +1,11 @@
+from types import SimpleNamespace
+
+from quick_ternaries.views.setup_menu_view import SetupMenuView
+
+
+def test_dependency_condition_supports_case_insensitive_tuple_values():
+    section_model = SimpleNamespace(legend_position="Custom")
+
+    assert SetupMenuView._dependency_condition_met(
+        section_model, ("legend_position", "custom")
+    )


### PR DESCRIPTION
## Summary

Adds global legend placement controls to the advanced setup settings and wires them into the active cartesian and ternary Plotly layouts. Also adds a local pre-commit whitespace check matching CI's `git diff --check` guard.

## What changed

- Replaces the free-form `legend_position` text field with preset options plus a `custom` mode.
- Adds Plotly-style custom legend controls for `x`, `y`, coordinate reference, anchors, and orientation.
- Applies legend settings through a shared `build_legend_layout` helper for cartesian and ternary plots.
- Extends setup form metadata handling for combo-box options, numeric spinbox ranges, and tuple dependencies.
- Adds regression tests for legend preset parsing, custom coordinates, Plotly layout application, and setup dependency behavior.
- Adds `.pre-commit-config.yaml`, a `dev` extra, and README setup notes for a staged `git diff --cached --check` hook.

## Why

The UI had a `legend_position` advanced setting, but the plot makers did not apply it. Heatmap colorbars already had per-trace coordinate controls; the legend is layout-level, so the new controls live in global advanced settings instead.

The initial PR CI run also showed that trailing whitespace can fail before tests start, so the hook gives contributors the same check before commit.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.pre-commit-config.yaml')"`
- `python -c "from setuptools.config import read_configuration; cfg = read_configuration('setup.cfg'); print(cfg['options']['extras_require']['dev'])"`
- `git diff --check origin/main`
- `python -m compileall quick_ternaries tests`
- `pytest`